### PR TITLE
Replace datetime with date

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ from fixedcal import FixedDate
 fixed_date = FixedDate.today()
 
 # From native datetime
-from datetime import datetime
-february_seventh = datetime(2022, 2, 7)
+import datetime
+february_seventh = datetime.date(2022, 2, 7)
 fixed_date = FixedDate(february_seventh)
 
 # From day's ordinal in year
@@ -35,10 +35,10 @@ fixed_date = FixedDate(day_of_year=107, year=2022)
 
 ```python3
 from fixedcal import FixedDate
-from datetime import datetime
-fixed_date = FixedDate(datetime(2022, 8, 12))
+import datetime
+fixed_date = FixedDate(datetime.date(2022, 8, 12))
 
-fixed_date.datetime       # datetime(2022, 8, 12, 0, 0, 0)
+fixed_date.date           # datetime.date(2022, 8, 12)
 fixed_date.day_of_year    # 224
 fixed_date.day_of_month   # 28
 fixed_date.month          # 8
@@ -56,10 +56,10 @@ fixed_date.year_quarter   # 3
 
 ```python3
 from fixedcal import FixedDate
-from datetime import datetime, timedelta
+from datetime import date, timedelta
 
-fixed_date = FixedDate(datetime(2022, 12, 6))
-jan_first = FixedDate(datetime(2023, 1, 1))
+fixed_date = FixedDate(date(2022, 12, 6))
+jan_first = FixedDate(date(2023, 1, 1))
 
 str(fixed_date)                       # 2022-13-04
 

--- a/fixedcal/core/date.py
+++ b/fixedcal/core/date.py
@@ -1,7 +1,6 @@
 """Module containing class for IFC date"""
 
-import datetime # as dt
-# from datetime import date, datetime, timedelta
+import datetime
 from fixedcal.services.leap_days import is_leap_year,\
     gregorian_leap_days_between, fixed_leap_days_between
 
@@ -206,7 +205,7 @@ class FixedDate:
         Does not modify either one of the values.
 
         Args:
-            o (Union[FixedDate, timedelta]): The value that will be added.
+            o (Union[FixedDate, datetime.timedelta]): The value that will be added.
 
         Raises:
             ValueError: Given argument was not FixedDate nor timedelta.

--- a/fixedcal/core/date.py
+++ b/fixedcal/core/date.py
@@ -1,7 +1,7 @@
 """Module containing class for IFC date"""
 
-import datetime as dt
-from datetime import datetime, timedelta
+import datetime # as dt
+# from datetime import date, datetime, timedelta
 from fixedcal.services.leap_days import is_leap_year,\
     gregorian_leap_days_between, fixed_leap_days_between
 
@@ -12,13 +12,13 @@ class FixedDate:
     both day_of_year and year arguments.
 
     Args:
-        date (Optional[datetime.datetime]): Gregorian date that will be represented
+        date (Optional[datetime.date]): Gregorian date that will be represented
         day_of_year (Optional[int]): The ordinal of the date in year. In range 1...366.
         year (Optional[int]): The year in range 1...9999.
     """
 
     def __init__(self,
-                date: dt.datetime = None,
+                date: datetime.date = None,
                 day_of_year: int = None,
                 year: int = None) -> None:
         if date is not None:
@@ -30,11 +30,11 @@ class FixedDate:
 
         self._day_of_year, self._year = init_tuple
 
-    def _from_datetime(self, date: dt.datetime) -> tuple:
+    def _from_datetime(self, date: datetime.date) -> tuple:
         """Initialize this class with native datetime object.
 
         Args:
-            date (datetime): _description_
+            date (datetime.date): _description_
 
         Returns:
             tuple: day of year (1...366) and year (1...9999) in a tuple
@@ -61,7 +61,7 @@ class FixedDate:
         Returns:
             FixedDate: Today as fixed date.
         """
-        return FixedDate(date=datetime.today())
+        return FixedDate(date=datetime.date.today())
 
     @property
     def is_leap_year(self) -> bool:
@@ -70,9 +70,6 @@ class FixedDate:
         Returns:
             bool: Is this leap year
         """
-        # if self._year % 100 == 0:
-        #     return self._year % 4 == 0 and self._year % 400 == 0
-        # return self._year % 4 == 0
         return is_leap_year(self._year)
 
     @property
@@ -85,13 +82,13 @@ class FixedDate:
         return self.is_leap_year and self._day_of_year == 169
 
     @property
-    def datetime(self) -> datetime:
-        """Construct a native datetime object from fixed date.
+    def date(self) -> datetime.date:
+        """Construct a native date object from fixed date.
 
         Returns:
-            datetime: Datetime equal to the fixed date.
+            datetime.date: Native date equal to the fixed date.
         """
-        return datetime(self.year, 1, 1) + timedelta(self._day_of_year-1)
+        return datetime.date(self.year, 1, 1) + datetime.timedelta(self._day_of_year-1)
 
     @property
     def day_of_year(self) -> int:
@@ -191,17 +188,17 @@ class FixedDate:
             return self._day_of_year > other.day_of_year
         return self._year > other.year
 
-    def __add__(self, other: timedelta) -> "FixedDate":
+    def __add__(self, other: datetime.timedelta) -> "FixedDate":
         """Addition of FixedDate and timedelta.
         Does not modify this instance, but creates new one.
 
         Args:
-            o (timedelta): The time delta that will be added.
+            o (datetime.timedelta): The time delta that will be added.
 
         Returns:
             FixedDate: New FixedDate instance that will hold the new date.
         """
-        new_date = self.datetime + other
+        new_date = self.date + other
         return FixedDate(date=new_date)
 
     def __sub__(self, other):
@@ -215,17 +212,17 @@ class FixedDate:
             ValueError: Given argument was not FixedDate nor timedelta.
 
         Returns:
-            Union[FixedDate, timedelta]: With FixedDate as argument,
+            Union[FixedDate, datetime.timedelta]: With FixedDate as argument,
             timedelta will be returned representing the difference of given fixed dates.
             With timedelta as argument, new FixedDate will be returned.
         """
         if isinstance(other, FixedDate):
-            difference = self.datetime - other.datetime
-            greg_leap_days = gregorian_leap_days_between(self.datetime, other.datetime)
-            fixed_leap_days = fixed_leap_days_between(self.datetime, other.datetime)
-            return difference - timedelta(greg_leap_days) + timedelta(fixed_leap_days)
-        if isinstance(other, timedelta):
-            new_date = self.datetime - other
+            difference = self.date - other.date
+            greg_leap_days = gregorian_leap_days_between(self.date, other.date)
+            fixed_leap_days = fixed_leap_days_between(self.date, other.date)
+            return difference - datetime.timedelta(greg_leap_days) + datetime.timedelta(fixed_leap_days)
+        if isinstance(other, datetime.timedelta):
+            new_date = self.date - other
             return FixedDate(date=new_date)
         raise ValueError("Invalid subtractor type, expected FixedDate or timedelta")
 

--- a/fixedcal/core/date.py
+++ b/fixedcal/core/date.py
@@ -219,7 +219,7 @@ class FixedDate:
             difference = self.date - other.date
             greg_leap_days = gregorian_leap_days_between(self.date, other.date)
             fixed_leap_days = fixed_leap_days_between(self.date, other.date)
-            return difference - datetime.timedelta(greg_leap_days) + datetime.timedelta(fixed_leap_days)
+            return difference + datetime.timedelta(fixed_leap_days - greg_leap_days)
         if isinstance(other, datetime.timedelta):
             new_date = self.date - other
             return FixedDate(date=new_date)

--- a/fixedcal/services/leap_days.py
+++ b/fixedcal/services/leap_days.py
@@ -1,4 +1,3 @@
-# from datetime import datetime, timedelta
 import datetime
 
 def is_leap_year(year: int) -> bool:
@@ -11,8 +10,8 @@ def gregorian_leap_days_between(date1: datetime.date, date2: datetime.date) -> i
     Count includes both ends (date1 and date2 themselves).
 
     Args:
-        date1 (datetime): The beginning of the count
-        date2 (datetime): The end of the count
+        date1 (datetime.date): The beginning of the count
+        date2 (datetime.date): The end of the count
 
     Returns:
         int: Count of the leap days.

--- a/fixedcal/services/leap_days.py
+++ b/fixedcal/services/leap_days.py
@@ -1,11 +1,12 @@
-from datetime import datetime, timedelta
+# from datetime import datetime, timedelta
+import datetime
 
 def is_leap_year(year: int) -> bool:
     if year % 100 == 0:
         return year % 4 == 0 and year % 400 == 0
     return year % 4 == 0
 
-def gregorian_leap_days_between(date1: datetime, date2: datetime) -> int:
+def gregorian_leap_days_between(date1: datetime.date, date2: datetime.date) -> int:
     """Counts the gregorian leap days (29th Feb) between given dates.
     Count includes both ends (date1 and date2 themselves).
 
@@ -21,18 +22,18 @@ def gregorian_leap_days_between(date1: datetime, date2: datetime) -> int:
         date1, date2 = date2, date1
     days_between = (date2 - date1).days
     for plusday in range(0, days_between):
-        date = date1 + timedelta(plusday)
+        date = date1 + datetime.timedelta(plusday)
         if is_leap_year(date.year) and date.month == 2 and date.day == 29:
             count += 1
     return count
 
-def fixed_leap_days_between(date1: datetime, date2: datetime) -> int:
+def fixed_leap_days_between(date1: datetime.date, date2: datetime.date) -> int:
     count = 0
     if date1 > date2:
         date1, date2 = date2, date1
     days_between = (date2 - date1).days
     for plusday in range(0, days_between):
-        date = date1 + timedelta(plusday)
+        date = date1 + datetime.timedelta(plusday)
         if is_leap_year(date.year) and date.month == 6 and date.day == 27:
             count += 1
     return count

--- a/tests/basic_datetime_test.py
+++ b/tests/basic_datetime_test.py
@@ -1,5 +1,4 @@
 import unittest
-# from datetime import datetime
 import datetime
 from fixedcal.core.date import FixedDate
 

--- a/tests/basic_datetime_test.py
+++ b/tests/basic_datetime_test.py
@@ -1,11 +1,12 @@
 import unittest
-from datetime import datetime
+# from datetime import datetime
+import datetime
 from fixedcal.core.date import FixedDate
 
-class TestBasicDatetimeInit(unittest.TestCase):
-    def test_datetime_init_january_first(self):
-        fixed_date = FixedDate(date=datetime(2022, 1, 1))
-        self.assertEqual(fixed_date.datetime, datetime(2022, 1, 1))
+class TestBasicDateInit(unittest.TestCase):
+    def test_date_init_january_first(self):
+        fixed_date = FixedDate(date=datetime.date(2022, 1, 1))
+        self.assertEqual(fixed_date.date, datetime.date(2022, 1, 1))
         self.assertEqual(fixed_date.year, 2022)
         self.assertEqual(fixed_date.month, 1)
         self.assertEqual(fixed_date.day_of_month, 1)
@@ -15,9 +16,9 @@ class TestBasicDatetimeInit(unittest.TestCase):
         self.assertEqual(fixed_date.week_of_year, 1)
         self.assertEqual(fixed_date.year_quarter, 1)
 
-    def test_datetime_init_february_last(self):
-        fixed_date = FixedDate(date=datetime(2022, 2, 25))
-        self.assertEqual(fixed_date.datetime, datetime(2022, 2, 25))
+    def test_date_init_february_last(self):
+        fixed_date = FixedDate(date=datetime.date(2022, 2, 25))
+        self.assertEqual(fixed_date.date, datetime.date(2022, 2, 25))
         self.assertEqual(fixed_date.year, 2022)
         self.assertEqual(fixed_date.month, 2)
         self.assertEqual(fixed_date.day_of_month, 28)
@@ -27,9 +28,9 @@ class TestBasicDatetimeInit(unittest.TestCase):
         self.assertEqual(fixed_date.week_of_year, 8)
         self.assertEqual(fixed_date.year_quarter, 1)
 
-    def test_datetime_init_sol_month(self):
-        fixed_date = FixedDate(date=datetime(2022, 6, 20))
-        self.assertEqual(fixed_date.datetime, datetime(2022, 6, 20))
+    def test_date_init_sol_month(self):
+        fixed_date = FixedDate(date=datetime.date(2022, 6, 20))
+        self.assertEqual(fixed_date.date, datetime.date(2022, 6, 20))
         self.assertEqual(fixed_date.year, 2022)
         self.assertEqual(fixed_date.month, 7)
         self.assertEqual(fixed_date.day_of_month, 3)
@@ -39,9 +40,9 @@ class TestBasicDatetimeInit(unittest.TestCase):
         self.assertEqual(fixed_date.week_of_year, 25)
         self.assertEqual(fixed_date.year_quarter, 2)
 
-    def test_datetime_init_middle_of_september(self):
-        fixed_date = FixedDate(date=datetime(2022, 9, 15))
-        self.assertEqual(fixed_date.datetime, datetime(2022, 9, 15))
+    def test_date_init_middle_of_september(self):
+        fixed_date = FixedDate(date=datetime.date(2022, 9, 15))
+        self.assertEqual(fixed_date.date, datetime.date(2022, 9, 15))
         self.assertEqual(fixed_date.year, 2022)
         self.assertEqual(fixed_date.month, 10)
         self.assertEqual(fixed_date.day_of_month, 6)
@@ -51,9 +52,9 @@ class TestBasicDatetimeInit(unittest.TestCase):
         self.assertEqual(fixed_date.week_of_year, 37)
         self.assertEqual(fixed_date.year_quarter, 3)
 
-    def test_datetime_init_december_last(self):
-        fixed_date = FixedDate(date=datetime(2022, 12, 30))
-        self.assertEqual(fixed_date.datetime, datetime(2022, 12, 30))
+    def test_date_init_december_last(self):
+        fixed_date = FixedDate(date=datetime.date(2022, 12, 30))
+        self.assertEqual(fixed_date.date, datetime.date(2022, 12, 30))
         self.assertEqual(fixed_date.year, 2022)
         self.assertEqual(fixed_date.month, 13)
         self.assertEqual(fixed_date.day_of_month, 28)
@@ -64,9 +65,9 @@ class TestBasicDatetimeInit(unittest.TestCase):
         self.assertEqual(fixed_date.week_of_year, 52)
         self.assertEqual(fixed_date.year_quarter, 4)
 
-    def test_datetime_init_year_day(self):
-        fixed_date = FixedDate(date=datetime(2022, 12, 31))
-        self.assertEqual(fixed_date.datetime, datetime(2022, 12, 31))
+    def test_date_init_year_day(self):
+        fixed_date = FixedDate(date=datetime.date(2022, 12, 31))
+        self.assertEqual(fixed_date.date, datetime.date(2022, 12, 31))
         self.assertEqual(fixed_date.year, 2022)
         self.assertEqual(fixed_date.month, 13)
         self.assertEqual(fixed_date.day_of_month, 29)
@@ -78,5 +79,5 @@ class TestBasicDatetimeInit(unittest.TestCase):
         self.assertEqual(fixed_date.year_quarter, 4)
 
     def test_today(self):
-        fixed_date_datetime = FixedDate.today().datetime
-        self.assertEqual(fixed_date_datetime.date(), datetime.today().date())
+        fixed_date_datetime = FixedDate.today().date
+        self.assertEqual(fixed_date_datetime, datetime.date.today())

--- a/tests/basic_day_of_year_test.py
+++ b/tests/basic_day_of_year_test.py
@@ -1,5 +1,4 @@
 import unittest
-from datetime import datetime
 from fixedcal.core.date import FixedDate
 
 class TestBasicDayOfYearInit(unittest.TestCase):

--- a/tests/leap_year_test.py
+++ b/tests/leap_year_test.py
@@ -1,5 +1,4 @@
 import unittest
-# from datetime import datetime, timedelta
 import datetime
 from fixedcal import FixedDate
 

--- a/tests/leap_year_test.py
+++ b/tests/leap_year_test.py
@@ -1,32 +1,33 @@
 import unittest
-from datetime import datetime, timedelta
+# from datetime import datetime, timedelta
+import datetime
 from fixedcal import FixedDate
 
 class TestLeapYear(unittest.TestCase):
     def test_leap_year_detection_with_simple_noleap(self):
         # 2022 is not divisible of four -> not a leap year
-        fixed_date = FixedDate(datetime(2022, 5, 4))
+        fixed_date = FixedDate(datetime.date(2022, 5, 4))
         self.assertFalse(fixed_date.is_leap_year)
 
     def test_leap_year_detection_with_complex_noleap(self):
         # 1900 is divisible of four but also by 100 and not by 400 -> not a leap year
-        fixed_date = FixedDate(datetime(1900, 5, 4))
+        fixed_date = FixedDate(datetime.date(1900, 5, 4))
         self.assertFalse(fixed_date.is_leap_year)
 
     def test_leap_year_detection_with_common_leap_year(self):
         # 2024 is divisible of four but not by 100 -> leap year
-        fixed_date = FixedDate(datetime(2024, 5, 4))
+        fixed_date = FixedDate(datetime.date(2024, 5, 4))
         self.assertTrue(fixed_date.is_leap_year)
 
     def test_leap_year_detection_with_centurial_leap_year(self):
         # 2000 is divisible of all four, 100 and 400 -> leap year
-        fixed_date = FixedDate(datetime(2000, 5, 4))
+        fixed_date = FixedDate(datetime.date(2000, 5, 4))
         self.assertTrue(fixed_date.is_leap_year)
 
 
     def test_fixed_leap_day_properties(self):
         # June 17th is the leap day of fixed calendar system
-        fixed_date = FixedDate(datetime(2024, 6, 17))
+        fixed_date = FixedDate(datetime.date(2024, 6, 17))
         self.assertEqual(fixed_date.day_of_month, 29)
         self.assertEqual(fixed_date.month, 6)
         self.assertIsNone(fixed_date.weekday)
@@ -42,7 +43,7 @@ class TestLeapYear(unittest.TestCase):
         self.assertEqual(fixed_date.day_of_month, 29)
 
     def test_ordinary_date_after_leap_day(self):
-        fixed_date = FixedDate(datetime(2024, 10, 13))
+        fixed_date = FixedDate(datetime.date(2024, 10, 13))
         self.assertEqual(fixed_date.month, 11)
         self.assertEqual(fixed_date.day_of_month, 6)
 
@@ -51,35 +52,35 @@ class TestLeapYear(unittest.TestCase):
         # in Gregorian system there are 7 days between,
         # but in IFC the leap day is at the end of June
         # and thus the difference should be just 6 days
-        date1 = FixedDate(datetime(2024, 2, 25))
-        date2 = FixedDate(datetime(2024, 3, 3))
-        self.assertEqual(date2-date1, timedelta(6))
+        date1 = FixedDate(datetime.date(2024, 2, 25))
+        date2 = FixedDate(datetime.date(2024, 3, 3))
+        self.assertEqual(date2-date1, datetime.timedelta(6))
 
     def test_fixed_date_difference_over_fixed_leap_day(self):
         # in Gregorian system there are 7 days between,
         # but in IFC the leap day is also in between
         # and therefore the difference should be 8 days
-        date1 = FixedDate(datetime(2024, 6, 27))
-        date2 = FixedDate(datetime(2024, 7, 4))
-        self.assertEqual(date2-date1, timedelta(8))
+        date1 = FixedDate(datetime.date(2024, 6, 27))
+        date2 = FixedDate(datetime.date(2024, 7, 4))
+        self.assertEqual(date2-date1, datetime.timedelta(8))
 
     def test_fixed_date_difference_with_itself_gregorian_leap_day(self):
-        date = FixedDate(datetime(2024, 2, 29))
-        self.assertEqual(date-date, timedelta(0))
+        date = FixedDate(datetime.date(2024, 2, 29))
+        self.assertEqual(date-date, datetime.timedelta(0))
 
     def test_fixed_date_difference_with_itself_fixed_leap_day(self):
-        date = FixedDate(datetime(2024, 6, 27))
-        self.assertEqual(date-date, timedelta(0))
+        date = FixedDate(datetime.date(2024, 6, 27))
+        self.assertEqual(date-date, datetime.timedelta(0))
 
     def test_fixed_date_difference_over_both_leap_days(self):
         # day count should be the same in both systems
-        date1 = FixedDate(datetime(2024, 2, 15))
-        date2 = FixedDate(datetime(2024, 8, 3))
-        self.assertEqual(date2-date1, timedelta(170))
+        date1 = FixedDate(datetime.date(2024, 2, 15))
+        date2 = FixedDate(datetime.date(2024, 8, 3))
+        self.assertEqual(date2-date1, datetime.timedelta(170))
 
     def test_fixed_date_difference_over_multiple_leap_days(self):
         # there are 3 Gregorian and 2 fixed leap days between
         # difference is 2987 days in Gregorian including Greg leap days
-        date1 = FixedDate(datetime(2020, 2, 15))
-        date2 = FixedDate(datetime(2028, 4, 20))
-        self.assertEqual(date2-date1, timedelta(2986))
+        date1 = FixedDate(datetime.date(2020, 2, 15))
+        date2 = FixedDate(datetime.date(2028, 4, 20))
+        self.assertEqual(date2-date1, datetime.timedelta(2986))

--- a/tests/operations_test.py
+++ b/tests/operations_test.py
@@ -1,5 +1,4 @@
 import unittest
-# from datetime import datetime, timedelta
 import datetime
 from fixedcal.core.date import FixedDate
 

--- a/tests/operations_test.py
+++ b/tests/operations_test.py
@@ -1,11 +1,12 @@
 import unittest
-from datetime import datetime, timedelta
+# from datetime import datetime, timedelta
+import datetime
 from fixedcal.core.date import FixedDate
 
 class TestOperations(unittest.TestCase):
     def setUp(self):
-        self.fixed1 = FixedDate(date=datetime(2022, 12, 5))
-        self.fixed2 = FixedDate(date=datetime(2022, 12, 6))
+        self.fixed1 = FixedDate(date=datetime.date(2022, 12, 5))
+        self.fixed2 = FixedDate(date=datetime.date(2022, 12, 6))
 
     def test_equal_with_two_same(self):
         self.assertTrue(self.fixed1 == self.fixed1)
@@ -26,33 +27,33 @@ class TestOperations(unittest.TestCase):
         self.assertTrue(self.fixed1 < self.fixed2)
 
     def test_subtration_of_two_dates(self):
-        self.assertEqual(self.fixed2-self.fixed1, timedelta(1))
+        self.assertEqual(self.fixed2-self.fixed1, datetime.timedelta(1))
 
     def test_subtration_of_two_dates_with_smaller_first(self):
-        self.assertEqual(self.fixed1-self.fixed2, timedelta(-1))
+        self.assertEqual(self.fixed1-self.fixed2, datetime.timedelta(-1))
 
     def test_subtration_of_two_same_dates(self):
-        self.assertEqual(self.fixed1-self.fixed1, timedelta(0))
+        self.assertEqual(self.fixed1-self.fixed1, datetime.timedelta(0))
 
     def test_subtraction_of_timedelta(self):
-        result = self.fixed1 - timedelta(7)
-        self.assertEqual(result, FixedDate(date=datetime(2022, 11, 28)))
+        result = self.fixed1 - datetime.timedelta(7)
+        self.assertEqual(result, FixedDate(date=datetime.date(2022, 11, 28)))
 
     def test_subtraction_of_negative_timedelta(self):
-        result = self.fixed1 - timedelta(-2)
-        self.assertEqual(result, FixedDate(date=datetime(2022, 12, 7)))
+        result = self.fixed1 - datetime.timedelta(-2)
+        self.assertEqual(result, FixedDate(date=datetime.date(2022, 12, 7)))
 
     def test_subtraction_of_invalid_type(self):
         self.assertRaises(ValueError, lambda : self.fixed1 - 3)
 
     def test_addition_of_timedelta(self):
-        result = self.fixed1 + timedelta(3)
-        self.assertEqual(result, FixedDate(date=datetime(2022, 12, 8)))
+        result = self.fixed1 + datetime.timedelta(3)
+        self.assertEqual(result, FixedDate(date=datetime.date(2022, 12, 8)))
 
     def test_addition_of_negative_timedelta(self):
-        result = self.fixed1 + timedelta(-3)
-        self.assertEqual(result, FixedDate(date=datetime(2022, 12, 2)))
+        result = self.fixed1 + datetime.timedelta(-3)
+        self.assertEqual(result, FixedDate(date=datetime.date(2022, 12, 2)))
 
     def test_addition_does_not_modify(self):
-        _ = self.fixed1 + timedelta(2)
-        self.assertEqual(self.fixed1.datetime, datetime(2022, 12, 5))
+        _ = self.fixed1 + datetime.timedelta(2)
+        self.assertEqual(self.fixed1.date, datetime.date(2022, 12, 5))

--- a/tests/string_repr_test.py
+++ b/tests/string_repr_test.py
@@ -1,5 +1,4 @@
 import unittest
-# from datetime import datetime
 import datetime
 from fixedcal import FixedDate
 

--- a/tests/string_repr_test.py
+++ b/tests/string_repr_test.py
@@ -1,14 +1,15 @@
 import unittest
-from datetime import datetime
+# from datetime import datetime
+import datetime
 from fixedcal import FixedDate
 
 class TestStringRepresentation(unittest.TestCase):
     def test_string_of_ordinary_date(self):
-        fixed_date = FixedDate(date=datetime(2022, 4, 15))
+        fixed_date = FixedDate(date=datetime.date(2022, 4, 15))
         self.assertEqual(str(fixed_date), "2022-04-21")
 
     def test_string_of_date_in_november(self):
-        fixed_date = FixedDate(date=datetime(2022, 11, 11))
+        fixed_date = FixedDate(date=datetime.date(2022, 11, 11))
         self.assertEqual(str(fixed_date), "2022-12-07")
 
     def test_string_of_year_day(self):


### PR DESCRIPTION
Times are not handled by `FixedDate` class, so the time of `datetime` instance is unused.